### PR TITLE
fix(release): pin changelog preset to the major the writer supports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
 				"@types/react-dom": "^19.2.7",
 				"@vitejs/plugin-react": "^6.1.1",
 				"@vitest/coverage-v8": "^5.0.0",
-				"conventional-changelog-conventionalcommits": "^10.4.0",
+				"conventional-changelog-conventionalcommits": "^9.3.1",
 				"eslint": "^10.10.0",
 				"eslint-plugin-react-hooks": "^7.1.1",
 				"eslint-plugin-react-refresh": "^0.5.6",
@@ -485,16 +485,6 @@
 			"optional": true,
 			"engines": {
 				"node": ">=0.1.90"
-			}
-		},
-		"node_modules/@conventional-changelog/template": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.4.0.tgz",
-			"integrity": "sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=22"
 			}
 		},
 		"node_modules/@csstools/color-helpers": {
@@ -3222,16 +3212,16 @@
 			}
 		},
 		"node_modules/conventional-changelog-conventionalcommits": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
-			"integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+			"integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"@conventional-changelog/template": "^1.4.0"
+				"compare-func": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=22"
+				"node": ">=18"
 			}
 		},
 		"node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"@types/react-dom": "^19.2.7",
 		"@vitejs/plugin-react": "^6.1.1",
 		"@vitest/coverage-v8": "^5.0.0",
-		"conventional-changelog-conventionalcommits": "^10.4.0",
+		"conventional-changelog-conventionalcommits": "^9.3.1",
 		"eslint": "^10.10.0",
 		"eslint-plugin-react-hooks": "^7.1.1",
 		"eslint-plugin-react-refresh": "^0.5.6",


### PR DESCRIPTION
## The failure

The `Semantic release` job on master fails at the `generateNotes` step ([run 34129509388](https://github.com/adrianeyre/frogger/actions/runs/34129509388/job/101766129958)):

```
Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer (conventional-changelog@8 or newer).
Your changelog tooling loaded an older writer which cannot render this preset.
Update the tooling or use an older major version of the preset."
```

Commit analysis succeeds (40 commits → minor release, v1.0.0); the run dies as soon as it tries to render the notes, so no tag, no release, and the `Build the site` / `Deploy to GitHub Pages` jobs never run.

## Cause

`conventional-changelog-conventionalcommits@10` uses handlebars helpers that only exist in `conventional-changelog-writer@9`. Both semantic-release plugins that load the preset pin the older writer:

```
├─┬ @semantic-release/commit-analyzer@13.0.1
│ └── conventional-changelog-writer@8.4.0
├─┬ @semantic-release/release-notes-generator@14.1.1
│ └── conventional-changelog-writer@8.4.0 deduped
└── conventional-changelog-conventionalcommits@10.4.0   ← needs writer@9
```

`14.1.1` is the latest stable `release-notes-generator` and it still declares `conventional-changelog-writer: ^8.0.0`, so there is no forward fix available — writer@9 only arrives with the semantic-release v25 plugin betas. Forcing writer@9 via an override would break the plugins, which use the writer@8 API.

## The change

Pin the preset to `^9.3.1`, the last major that renders against writer@8. One-line dependency change plus the lockfile.

Worth revisiting once `@semantic-release/release-notes-generator@15` ships stable — that line moves to writer@9 and the v10 preset becomes usable again.

## Verification

- Drove `@semantic-release/release-notes-generator` directly with this repo's `.releaserc.json` `presetConfig` over sample `feat` / `fix` / `perf` / breaking-change commits. Notes render, and the configured section names (`Features`, `Bug Fixes`, `Performance`, `⚠ BREAKING CHANGES`) come through.
- Full verify suite locally: `format:check`, `lint`, `typecheck`, `test` (30 passed / 8 files), `build` — all pass.

The release path itself can only be proven by the merge to master, since semantic-release refuses to dry-run against a non-release branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)